### PR TITLE
Fix for broken deprecated syntax in React and webpack

### DIFF
--- a/app/components/message-creator.jsx
+++ b/app/components/message-creator.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class MessageCreator extends Component {
   static propTypes = {

--- a/app/components/message-creator.jsx
+++ b/app/components/message-creator.jsx
@@ -8,7 +8,7 @@ class MessageCreator extends Component {
   createMessage(e) {
     e.preventDefault();
 
-    const contentNode = this.refs.content.getDOMNode();
+    const contentNode = this.refs.content;
 
     this.props.create(contentNode.value);
     contentNode.value = '';

--- a/app/components/message.jsx
+++ b/app/components/message.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 
 class Message extends Component {

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import Message from './components/message';
 import MessageCreator from './components/message-creator';
-import css from './main.css'
+import css from './main.css';
 
 class App extends Component {
   constructor(props) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,12 @@ module.exports = {
     filename: 'bundle.js'
   },
   resolve: {
-    extensions: [ '', '.js', '.jsx' ]
+    extensions: [ '.js', '.jsx' ]
   },
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loader: 'babel',
+      loader: 'babel-loader',
       query: {
         presets: ['es2015', 'stage-0', 'react']
       }


### PR DESCRIPTION
app/components/message-creator.jsx: getDOMNode() is no longer required
and throws an error. Removing it allows the code to work as expected.

app/main.jsx just added a missing semi-colon.

webpack.config.js: fixing for webpack v2 - removing empty leading
element in resolve extensions array and adding required "-loader"
syntax for the babel loader.